### PR TITLE
Editorconfig rules with formatter

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,21 +1,13 @@
-[*.{css,scss,less,js,json,ts,sass,html,hbs,mustache,phtml,html.twig,md,yml}]
+[*.{css,hbs,html,js,json,less,md,mustache,php,phtml,sass,scss,ts,twig}]
 charset = utf-8
-indent_style = space
-indent_size = 2
+indent_style = tab
 end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.md]
-indent_size = 4
-trim_trailing_whitespace = false
-
-[site/templates/**.php]
-indent_size = 2
-
-[site/snippets/**.php]
-indent_size = 2
-
-[package.json,.{babelrc,editorconfig,eslintrc,lintstagedrc,stylelintrc}]
+[*.yml]
 indent_style = space
 indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,16 @@ Icon
 /media/*
 !/media/index.html
 
+# Node files
+# ---------------
+
+/node_modules
+
 # Lock files
 # ---------------
 
 .lock
+*.lockb
 
 # Editors
 # (sensitive workspace files)

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Ignore kirby submodule
+kirby

--- a/README.md
+++ b/README.md
@@ -27,16 +27,16 @@ If you are familiar with Git, you can clone Kirby's Starterkit repository from G
 
 ## What's Kirby?
 
--   **[getkirby.com](https://getkirby.com)** – Get to know the CMS.
--   **[Try it](https://getkirby.com/try)** – Take a test ride with our online demo. Or download one of our kits to get started.
--   **[Documentation](https://getkirby.com/docs/guide)** – Read the official guide, reference and cookbook recipes.
--   **[Issues](https://github.com/getkirby/kirby/issues)** – Report bugs and other problems.
--   **[Feedback](https://feedback.getkirby.com)** – You have an idea for Kirby? Share it.
--   **[Forum](https://forum.getkirby.com)** – Whenever you get stuck, don't hesitate to reach out for questions and support.
--   **[Discord](https://chat.getkirby.com)** – Hang out and meet the community.
--   **[YouTube](https://youtube.com/kirbyCasts)** - Watch the latest video tutorials visually with Bastian.
--   **[Mastodon](https://mastodon.social/@getkirby)** – Spread the word.
--   **[Instagram](https://www.instagram.com/getkirby/)** – Share your creations: #madewithkirby.
+- **[getkirby.com](https://getkirby.com)** – Get to know the CMS.
+- **[Try it](https://getkirby.com/try)** – Take a test ride with our online demo. Or download one of our kits to get started.
+- **[Documentation](https://getkirby.com/docs/guide)** – Read the official guide, reference and cookbook recipes.
+- **[Issues](https://github.com/getkirby/kirby/issues)** – Report bugs and other problems.
+- **[Feedback](https://feedback.getkirby.com)** – You have an idea for Kirby? Share it.
+- **[Forum](https://forum.getkirby.com)** – Whenever you get stuck, don't hesitate to reach out for questions and support.
+- **[Discord](https://chat.getkirby.com)** – Hang out and meet the community.
+- **[YouTube](https://youtube.com/kirbyCasts)** - Watch the latest video tutorials visually with Bastian.
+- **[Mastodon](https://mastodon.social/@getkirby)** – Spread the word.
+- **[Instagram](https://www.instagram.com/getkirby/)** – Share your creations: #madewithkirby.
 
 ---
 

--- a/assets/css/index.css
+++ b/assets/css/index.css
@@ -1,445 +1,445 @@
 * {
-  margin: 0;
-  padding: 0;
+	margin: 0;
+	padding: 0;
 }
 
 :root {
-  --padding: 1.5rem;
-  --color-black: #000;
-  --color-white: #fff;
-  --color-grey: #777;
-  --color-light: #efefef;
-  --color-text: var(--color-black);
-  --color-text-grey: var(--color-grey);
-  --color-background: var(--color-white);
-  --color-code-light-grey:  #cacbd1;
-  --color-code-comment:     #a9aaad;
-  --color-code-white:       #c5c9c6;
-  --color-code-red:         #d16464;
-  --color-code-orange:      #de935f;
-  --color-code-yellow:      #f0c674;
-  --color-code-green:       #a7bd68;
-  --color-code-aqua:        #8abeb7;
-  --color-code-blue:        #7e9abf;
-  --color-code-purple:      #b294bb;
-  --font-family-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-  --font-family-mono: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+	--padding: 1.5rem;
+	--color-black: #000;
+	--color-white: #fff;
+	--color-grey: #777;
+	--color-light: #efefef;
+	--color-text: var(--color-black);
+	--color-text-grey: var(--color-grey);
+	--color-background: var(--color-white);
+	--color-code-light-grey:  #cacbd1;
+	--color-code-comment:     #a9aaad;
+	--color-code-white:       #c5c9c6;
+	--color-code-red:         #d16464;
+	--color-code-orange:      #de935f;
+	--color-code-yellow:      #f0c674;
+	--color-code-green:       #a7bd68;
+	--color-code-aqua:        #8abeb7;
+	--color-code-blue:        #7e9abf;
+	--color-code-purple:      #b294bb;
+	--font-family-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+	--font-family-mono: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
 }
 
 html {
-  font-family: var(--font-family-sans);
-  color: var(--color-text);
-  background: var(--color-background);
+	font-family: var(--font-family-sans);
+	color: var(--color-text);
+	background: var(--color-background);
 }
 img {
-  width: 100%;
+	width: 100%;
 }
 body {
-  padding: var(--padding);
-  max-width: 70rem;
-  margin: 0 auto;
+	padding: var(--padding);
+	max-width: 70rem;
+	margin: 0 auto;
 }
 li {
-  list-style: none;
+	list-style: none;
 }
 a {
-  color: currentColor;
-  text-decoration: none;
+	color: currentColor;
+	text-decoration: none;
 }
 button {
-  font: inherit;
-  background: none;
-  border: 0;
-  color: currentColor;
-  cursor: pointer;
+	font: inherit;
+	background: none;
+	border: 0;
+	color: currentColor;
+	cursor: pointer;
 }
 strong, b {
-  font-weight: 600;
+	font-weight: 600;
 }
 small {
-  font-size: inherit;
-  color: var(--color-text-grey);
+	font-size: inherit;
+	color: var(--color-text-grey);
 }
 
 .bg-light {
-  background-color: var(--color-light);
+	background-color: var(--color-light);
 }
 .color-grey {
-  color: var(--color-text-grey);
+	color: var(--color-text-grey);
 }
 
 .header {
-  position: relative;
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  align-items: center;
-  margin-right: -1rem;
-  margin-left: -1rem;
-  margin-bottom: 6rem;
+	position: relative;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	align-items: center;
+	margin-right: -1rem;
+	margin-left: -1rem;
+	margin-bottom: 6rem;
 }
 
 .logo {
-  padding: 1rem;
-  display: flex;
-  align-items: center;
-  font-weight: 600;
-  cursor: pointer;
+	padding: 1rem;
+	display: flex;
+	align-items: center;
+	font-weight: 600;
+	cursor: pointer;
 }
 
 @media (min-width: 600px) {
-  .logo img {
-    width: 138px;
-  }
+	.logo img {
+		width: 138px;
+	}
 }
 
 @media (max-width: 599px) {
-  .logo img {
-    width: 69px;
-  }
+	.logo img {
+		width: 69px;
+	}
 }
 
 .menu {
-  display: flex;
+	display: flex;
 }
 .menu a {
-  padding: 1rem;
-  display: block;
+	padding: 1rem;
+	display: block;
 }
 .menu a[aria-current] {
-  text-decoration: underline;
+	text-decoration: underline;
 }
 
 .social {
-  display: flex;
-  padding: 0 .5rem;
+	display: flex;
+	padding: 0 .5rem;
 }
 .social a {
-  padding: 1rem .5rem;
+	padding: 1rem .5rem;
 }
 
 .section {
-  padding: 3rem 0;
+	padding: 3rem 0;
 }
 
 .grid {
-  --columns: 12;
-  --gutter: 3rem;
-  display: grid;
-  grid-gap: var(--gutter);
-  grid-template-columns: 1fr;
+	--columns: 12;
+	--gutter: 3rem;
+	display: grid;
+	grid-gap: var(--gutter);
+	grid-template-columns: 1fr;
 }
 .grid > .column {
-  margin-bottom: var(--gutter);
+	margin-bottom: var(--gutter);
 }
 
 .autogrid {
-  --gutter: 3rem;
-  --min: 10rem;
-  display: grid;
-  grid-gap: var(--gutter);
-  grid-template-columns: repeat(auto-fit, minmax(var(--min), 1fr));
-  grid-auto-flow: dense;
+	--gutter: 3rem;
+	--min: 10rem;
+	display: grid;
+	grid-gap: var(--gutter);
+	grid-template-columns: repeat(auto-fit, minmax(var(--min), 1fr));
+	grid-auto-flow: dense;
 }
 
 h1, h2, h3, h4, h5, h6 {
-  font-size: inherit;
-  font-weight: inherit;
-  line-height: inherit;
+	font-size: inherit;
+	font-weight: inherit;
+	line-height: inherit;
 }
 
 .text {
-  line-height: 1.5em;
+	line-height: 1.5em;
 }
 .text a {
-  text-decoration: underline;
+	text-decoration: underline;
 }
 .text :first-child {
-  margin-top: 0;
+	margin-top: 0;
 }
 .text :last-child {
-  margin-bottom: 0;
+	margin-bottom: 0;
 }
 .text p,
 .text ul,
 .text ol {
-  margin-bottom: 1.5rem;
+	margin-bottom: 1.5rem;
 }
 .text ul,
 .text ol {
-  margin-left: 1rem;
+	margin-left: 1rem;
 }
 .text ul p,
 .text ol p {
-  margin-bottom: 0;
+	margin-bottom: 0;
 }
 .text ul > li {
-  list-style: disc;
+	list-style: disc;
 }
 .text ol > li {
-  list-style: decimal;
+	list-style: decimal;
 }
 .text ul ol,
 .text ul ul,
 .text ol ul,
 .text ol ol {
-  margin-bottom: 0;
+	margin-bottom: 0;
 }
 .text h1,
 .h1,
 .intro {
-  font-size: 2rem;
-  margin-bottom: 3rem;
-  line-height: 1.25em;
+	font-size: 2rem;
+	margin-bottom: 3rem;
+	line-height: 1.25em;
 }
 .text h2,
 .h2 {
-  font-size: 1.25rem;
-  font-weight: 600;
-  margin-bottom: 1.25rem;
+	font-size: 1.25rem;
+	font-weight: 600;
+	margin-bottom: 1.25rem;
 }
 .text h3,
 .h3 {
-  font-weight: 600;
+	font-weight: 600;
 }
 .text .codeblock {
-  display: grid;
+	display: grid;
 }
 .text code {
-  font-family: var(--font-family-mono);
-  font-size: 1em;
-  background: var(--color-light);
-  padding: 0 .5rem;
-  display: inline-block;
-  color: var(--color-black);
+	font-family: var(--font-family-mono);
+	font-size: 1em;
+	background: var(--color-light);
+	padding: 0 .5rem;
+	display: inline-block;
+	color: var(--color-black);
 }
 .text pre {
-  margin: 3rem 0;
-  background: var(--color-black);
-  color: var(--color-white);
-  padding: 1.5rem;
-  overflow-x: scroll;
-  overflow-y: hidden;
-  line-height: 1.5rem;
+	margin: 3rem 0;
+	background: var(--color-black);
+	color: var(--color-white);
+	padding: 1.5rem;
+	overflow-x: scroll;
+	overflow-y: hidden;
+	line-height: 1.5rem;
 }
 .text pre code {
-  padding: 0;
-  background: none;
-  color: inherit;
+	padding: 0;
+	background: none;
+	color: inherit;
 }
 .text hr {
-  margin: 6rem 0;
+	margin: 6rem 0;
 }
 .text dt {
-  font-weight: 600;
+	font-weight: 600;
 }
 .text blockquote {
-  font-size: 1.25rem;
-  line-height: 1.325em;
-  border-left: 2px solid var(--color-black);
-  padding-left: 1rem;
-  margin: 3rem 0;
-  max-width: 25rem;
+	font-size: 1.25rem;
+	line-height: 1.325em;
+	border-left: 2px solid var(--color-black);
+	padding-left: 1rem;
+	margin: 3rem 0;
+	max-width: 25rem;
 }
 .text blockquote footer {
-  font-size: .875rem;
-  font-style: italic;
+	font-size: .875rem;
+	font-style: italic;
 }
 .text figure {
-  margin: 3rem 0;
+	margin: 3rem 0;
 }
 .text figcaption {
-  padding-top: .75rem;
-  color: var(--color-text-grey);
+	padding-top: .75rem;
+	color: var(--color-text-grey);
 }
 .text figure ul {
-  line-height: 0;
-  display: grid;
-  gap: 1.5rem;
-  margin: 0;
-  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+	line-height: 0;
+	display: grid;
+	gap: 1.5rem;
+	margin: 0;
+	grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
 }
 .text figure ul li {
-  list-style: none;
+	list-style: none;
 }
 
 hr {
-  border: 0;
-  background: currentColor;
-  height: 2px;
-  width: 1.5rem;
-  margin: 3rem auto;
+	border: 0;
+	background: currentColor;
+	height: 2px;
+	width: 1.5rem;
+	margin: 3rem auto;
 }
 
 .align-center {
-  text-align: center;
+	text-align: center;
 }
 
 .intro {
-  max-width: 40rem;
+	max-width: 40rem;
 }
 .intro *:not(:last-child) {
-  margin-bottom: 1em;
+	margin-bottom: 1em;
 }
 
 .cta {
-  background: var(--color-black);
-  color: var(--color-white);
-  display: inline-flex;
-  justify-content: center;
-  padding: .75rem 1.5rem;
-  border: 4px solid var(--color-white);
-  outline: 2px solid var(--color-black);
+	background: var(--color-black);
+	color: var(--color-white);
+	display: inline-flex;
+	justify-content: center;
+	padding: .75rem 1.5rem;
+	border: 4px solid var(--color-white);
+	outline: 2px solid var(--color-black);
 }
 
 .box {
-  background: var(--color-light);
-  padding: 1.5rem;
-  border: 4px solid var(--color-white);
-  outline: 2px solid var(--color-light);
+	background: var(--color-light);
+	padding: 1.5rem;
+	border: 4px solid var(--color-white);
+	outline: 2px solid var(--color-light);
 }
 
 .video,
 .img {
-  position: relative;
-  display: block;
-  --w: 1;
-  --h: 1;
-  padding-bottom: calc(100% / var(--w) * var(--h));
-  background: var(--color-black);
+	position: relative;
+	display: block;
+	--w: 1;
+	--h: 1;
+	padding-bottom: calc(100% / var(--w) * var(--h));
+	background: var(--color-black);
 }
 .img img,
 .video iframe {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  border: 0;
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	border: 0;
 }
 .img[data-contain] img {
-  object-fit: contain;
+	object-fit: contain;
 }
 .img-caption,
 .video-caption {
-  padding-top: .75rem;
-  line-height: 1.5em;
+	padding-top: .75rem;
+	line-height: 1.5em;
 }
 
 .footer {
-  padding: 9rem 0 6rem;
-  line-height: 1.5em;
+	padding: 9rem 0 6rem;
+	line-height: 1.5em;
 }
 .footer:before {
-  content: "";
-  display: block;
-  width: 1.5rem;
-  height: 2px;
-  background: var(--color-black);
-  margin-bottom: 1.5rem;
+	content: "";
+	display: block;
+	width: 1.5rem;
+	height: 2px;
+	background: var(--color-black);
+	margin-bottom: 1.5rem;
 }
 
 .footer h2 {
-  font-weight: 600;
-  margin-bottom: .75rem;
+	font-weight: 600;
+	margin-bottom: .75rem;
 }
 .footer ul,
 .footer p {
-  color: var(--color-text-grey);
+	color: var(--color-text-grey);
 }
 .footer p {
-  max-width: 30rem; /* note JT: valeur initiale 15rem */
+	max-width: 30rem; /* note JT: valeur initiale 15rem */
 }
 .footer a:hover {
-  color: var(--color-text);
+	color: var(--color-text);
 }
 
 
 .map {
-  --w: 2;
-  --h: 1;
-  padding-bottom: calc(100% / var(--w) * var(--h));
-  position: relative;
-  overflow: hidden;
-  background: var(--color-black);
+	--w: 2;
+	--h: 1;
+	padding-bottom: calc(100% / var(--w) * var(--h));
+	position: relative;
+	overflow: hidden;
+	background: var(--color-black);
 }
 .map iframe {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  border: 0;
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	border: 0;
 }
 
 .margin-s {
-  margin-bottom: .75rem;
+	margin-bottom: .75rem;
 }
 .margin-m {
-  margin-bottom: 1.5rem;
+	margin-bottom: 1.5rem;
 }
 .margin-l {
-  margin-bottom: 3rem;
+	margin-bottom: 3rem;
 }
 .margin-xl {
-  margin-bottom: 4.5rem;
+	margin-bottom: 4.5rem;
 }
 .margin-xxl {
-  margin-bottom: 6rem;
+	margin-bottom: 6rem;
 }
 
 
 @media screen and (min-width: 60rem) {
-  body {
-    --padding: 3rem;
-  }
+	body {
+		--padding: 3rem;
+	}
 
-  .grid {
-    grid-template-columns: repeat(12, 1fr);
-  }
-  .grid > .column {
-    grid-column: span var(--columns);
-  }
+	.grid {
+		grid-template-columns: repeat(12, 1fr);
+	}
+	.grid > .column {
+		grid-column: span var(--columns);
+	}
 
 }
 
 .pagination {
-  display: flex;
-  padding-top: 6rem;
+	display: flex;
+	padding-top: 6rem;
 }
 .pagination > span {
-  color: var(--color-text-grey);
+	color: var(--color-text-grey);
 }
 .pagination > * {
-  padding: .5rem;
-  width: 3rem;
-  text-align: center;
-  border: 2px solid currentColor;
-  margin-right: 1.5rem;
+	padding: .5rem;
+	width: 3rem;
+	text-align: center;
+	border: 2px solid currentColor;
+	margin-right: 1.5rem;
 }
 .pagination > a:hover {
-  background: var(--color-black);
-  color: var(--color-white);
-  border-color: var(--color-black);
+	background: var(--color-black);
+	color: var(--color-white);
+	border-color: var(--color-black);
 }
 
 .note-excerpt {
-  line-height: 1.5em;
+	line-height: 1.5em;
 }
 .note-excerpt header {
-  margin-bottom: 1.5rem;
+	margin-bottom: 1.5rem;
 }
 .note-excerpt figure {
-  margin-bottom: .5rem;
+	margin-bottom: .5rem;
 }
 .note-excerpt-title {
-  font-weight: 600;
+	font-weight: 600;
 }
 .note-excerpt-date {
-  color: var(--color-text-grey);
+	color: var(--color-text-grey);
 }

--- a/assets/css/templates/home.css
+++ b/assets/css/templates/home.css
@@ -1,129 +1,129 @@
 .home-grid {
-  display: grid;
-  list-style: none;
-  grid-gap: 1.5rem;
-  line-height: 0;
-  grid-template-columns: repeat(1, 1fr);
-  grid-auto-flow: dense;
+	display: grid;
+	list-style: none;
+	grid-gap: 1.5rem;
+	line-height: 0;
+	grid-template-columns: repeat(1, 1fr);
+	grid-auto-flow: dense;
 }
 .home-grid li {
-  position: relative;
-  --cols: 1;
-  --rows: 1;
+	position: relative;
+	--cols: 1;
+	--rows: 1;
 
-  overflow: hidden;
-  background: #000;
-  line-height: 0;
+	overflow: hidden;
+	background: #000;
+	line-height: 0;
 }
 .home-grid li:first-child {
-  --cols: 2;
-  --rows: 2;
+	--cols: 2;
+	--rows: 2;
 }
 .home-grid li:nth-child(5) {
-  --cols: 2;
+	--cols: 2;
 }
 .home-grid li:nth-child(6) {
-  --rows: 2;
+	--rows: 2;
 }
 .home-grid li:nth-child(7) {
-  --cols: 2;
+	--cols: 2;
 }
 .home-grid a {
-  display: block;
-  height: 10rem;
+	display: block;
+	height: 10rem;
 }
 .home-grid img {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  transition: all .3s;
+	position: absolute;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	transition: all 0.3s;
 }
 .home-grid figcaption {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  position: absolute;
-  color: #fff;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  line-height: 1;
-  text-align: center;
-  background: rgba(0,0,0, .5);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	position: absolute;
+	color: #fff;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	line-height: 1;
+	text-align: center;
+	background: rgba(0, 0, 0, 0.5);
 }
 
 @media screen and (min-width: 45em) {
-  .home-grid {
-    grid-template-columns: repeat(3, 1fr);
-  }
-  .home-grid li {
-    grid-column-start: span var(--cols);
-    grid-row-start: span var(--rows);
-  }
-  .home-grid a {
-    padding-bottom: 52.65%;
-  }
+	.home-grid {
+		grid-template-columns: repeat(3, 1fr);
+	}
+	.home-grid li {
+		grid-column-start: span var(--cols);
+		grid-row-start: span var(--rows);
+	}
+	.home-grid a {
+		padding-bottom: 52.65%;
+	}
 }
 .shop-icons {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
 }
 
 h3 {
-  font-style: italic;
-  font-weight: bold;
-  margin-top: 1rem;
-  font-size: larger;
+	font-style: italic;
+	font-weight: bold;
+	margin-top: 1rem;
+	font-size: larger;
 }
 
 p {
-  margin-top: 1rem;
-  margin-bottom: 1rem;
+	margin-top: 1rem;
+	margin-bottom: 1rem;
 }
 
 ol li {
-  list-style: symbols;
-  margin-left: 3rem;
+	list-style: symbols;
+	margin-left: 3rem;
 }
 
 .gallery ul {
-  display: flex;
-  justify-content: center;
+	display: flex;
+	justify-content: center;
 }
 
 button {
-  border: 1px solid black;
-  border-radius: 3rem;
-  display: inline-flex;
-  padding: .5rem 3rem;
-  cursor: pointer;
-  background-color: #DEDC3A;
-  color: black;
-  font-weight: 300;
-  opacity: 0.8;
-  transition: opacity 0.3s ease;
-  text-align: center;
-  margin-inline: auto;
-  display: block;
-  width: fit-content;
+	border: 1px solid black;
+	border-radius: 3rem;
+	display: inline-flex;
+	padding: 0.5rem 3rem;
+	cursor: pointer;
+	background-color: #dedc3a;
+	color: black;
+	font-weight: 300;
+	opacity: 0.8;
+	transition: opacity 0.3s ease;
+	text-align: center;
+	margin-inline: auto;
+	display: block;
+	width: fit-content;
 }
 
 button:hover {
-  opacity: 1;
+	opacity: 1;
 }
 
 button:empty::after {
-  content: "Texte du bouton …";
-  color: var(--color-text-light);
+	content: "Texte du bouton …";
+	color: var(--color-text-light);
 }
 button:focus {
-  outline: 0;
-  border-color: var(--color-focus);
+	outline: 0;
+	border-color: var(--color-focus);
 }

--- a/composer.json
+++ b/composer.json
@@ -1,40 +1,40 @@
 {
-  "name": "getkirby/starterkit",
-  "description": "Kirby Starterkit",
-  "type": "project",
-  "keywords": [
-    "kirby",
-    "cms",
-    "starterkit"
-  ],
-  "authors": [
-    {
-      "name": "Bastian Allgeier",
-      "email": "bastian@getkirby.com",
-      "homepage": "https://getkirby.com"
-    }
-  ],
-  "homepage": "https://getkirby.com",
-  "support": {
-    "email": "support@getkirby.com",
-    "issues": "https://github.com/getkirby/starterkit/issues",
-    "forum": "https://forum.getkirby.com",
-    "source": "https://github.com/getkirby/starterkit"
-  },
-  "require": {
-    "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-    "getkirby/cms": "^4.0"
-  },
-  "config": {
-    "allow-plugins": {
-      "getkirby/composer-installer": true
-    },
-    "optimize-autoloader": true
-  },
-  "scripts": {
-    "start": [
-      "Composer\\Config::disableProcessTimeout",
-      "@php -S localhost:8000 kirby/router.php"
-    ]
-  }
+	"name": "getkirby/starterkit",
+	"description": "Kirby Starterkit",
+	"type": "project",
+	"keywords": [
+		"kirby",
+		"cms",
+		"starterkit"
+	],
+	"authors": [
+		{
+			"name": "Bastian Allgeier",
+			"email": "bastian@getkirby.com",
+			"homepage": "https://getkirby.com"
+		}
+	],
+	"homepage": "https://getkirby.com",
+	"support": {
+		"email": "support@getkirby.com",
+		"issues": "https://github.com/getkirby/starterkit/issues",
+		"forum": "https://forum.getkirby.com",
+		"source": "https://github.com/getkirby/starterkit"
+	},
+	"require": {
+		"php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+		"getkirby/cms": "^4.0"
+	},
+	"config": {
+		"allow-plugins": {
+			"getkirby/composer-installer": true
+		},
+		"optimize-autoloader": true
+	},
+	"scripts": {
+		"start": [
+			"Composer\\Config::disableProcessTimeout",
+			"@php -S localhost:8000 kirby/router.php"
+		]
+	}
 }

--- a/index.php
+++ b/index.php
@@ -1,5 +1,5 @@
 <?php
 
-require __DIR__ . '/kirby/bootstrap.php';
+require __DIR__ . "/kirby/bootstrap.php";
 
-echo (new Kirby)->render();
+echo (new Kirby())->render();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+	"dependencies": {},
+	"devDependencies": {
+		"@prettier/plugin-php": "^0.22.2",
+		"prettier": "^3.2.5"
+	},
+	"prettier": {
+		"plugins": [
+			"@prettier/plugin-php"
+		]
+	},
+	"scripts": {
+		"format": "prettier . --write"
+	}
+}

--- a/site/blueprints/files/image.yml
+++ b/site/blueprints/files/image.yml
@@ -7,7 +7,7 @@ title: Image
 # when this blueprint is used, which allows you to control what users can upload.
 # More about file blueprints: https://getkirby.com/docs/reference/panel/blueprints/file
 
-accept: 
+accept:
   type: image
 
 columns:

--- a/site/blueprints/pages/default.yml
+++ b/site/blueprints/pages/default.yml
@@ -39,4 +39,3 @@ columns:
       # Files section: https://getkirby.com/docs/reference/panel/sections/files
       files:
         type: files
-

--- a/site/blueprints/pages/home.yml
+++ b/site/blueprints/pages/home.yml
@@ -12,9 +12,7 @@ options:
 
 # on the left column we define a form to update text fields
 
-
 tabs:
-
   part_0:
     icon: text
     label: Titre

--- a/site/config/config.php
+++ b/site/config/config.php
@@ -3,10 +3,10 @@
 /**
  * The config file is optional. It accepts a return array with config options
  * Note: Never include more than one return statement, all options go within this single return array
- * In this example, we set debugging to true, so that errors are displayed onscreen. 
+ * In this example, we set debugging to true, so that errors are displayed onscreen.
  * This setting must be set to false in production.
  * All config options: https://getkirby.com/docs/reference/system/options
  */
 return [
-    'debug' => true,
+	"debug" => true,
 ];

--- a/site/plugins/button/index.css
+++ b/site/plugins/button/index.css
@@ -1,34 +1,33 @@
 .k-block-type-button {
-  display: flex;
-  justify-content: center;
-  align-items: center;
+	display: flex;
+	justify-content: center;
+	align-items: center;
 }
 
-
 .k-block-type-button button {
-  border: 1px solid black;
-  border-radius: 3rem;
-  display: inline-flex;
-  padding: .5rem 3rem;
-  cursor: pointer;
-  background-color: #DEDC3A;
-  color: black;
-  font-weight: 300;
-  opacity: 0.8;
-  width: auto;
-  transition: opacity 0.3s ease;
-  text-align: center;
+	border: 1px solid black;
+	border-radius: 3rem;
+	display: inline-flex;
+	padding: 0.5rem 3rem;
+	cursor: pointer;
+	background-color: #dedc3a;
+	color: black;
+	font-weight: 300;
+	opacity: 0.8;
+	width: auto;
+	transition: opacity 0.3s ease;
+	text-align: center;
 }
 
 .k-block-type-button button:hover {
-  opacity: 1;
+	opacity: 1;
 }
 
 .k-block-type-button button:empty::after {
-  content: "Texte du bouton …";
-  color: var(--color-text-light);
+	content: "Texte du bouton …";
+	color: var(--color-text-light);
 }
 .k-block-type-button button:focus {
-  outline: 0;
-  border-color: var(--color-focus);
+	outline: 0;
+	border-color: var(--color-focus);
 }

--- a/site/plugins/button/index.js
+++ b/site/plugins/button/index.js
@@ -1,9 +1,9 @@
 panel.plugin("your-project/button-block", {
-  blocks: {
-    button: `
-      <button type="button" @click="open">
-        {{ content.text }}
-      </button>
-    `
-  }
+	blocks: {
+		button: `
+			<button type="button" @click="open">
+				{{ content.text }}
+			</button>
+		`,
+	},
 });

--- a/site/plugins/button/index.php
+++ b/site/plugins/button/index.php
@@ -1,3 +1,3 @@
 <?php
 
-Kirby::plugin('your-project/button-block', []);
+Kirby::plugin("your-project/button-block", []);

--- a/site/snippets/blocks/button.php
+++ b/site/snippets/blocks/button.php
@@ -1,5 +1,5 @@
 <button>
-  <a href="<?= $block->link() ?>">
-    <?= $block->text() ?>
-  </a>
+	<a href="<?= $block->link() ?>">
+		<?= $block->text() ?>
+	</a>
 </button>

--- a/site/snippets/blocks/gallery.php
+++ b/site/snippets/blocks/gallery.php
@@ -2,22 +2,22 @@
 /** @var \Kirby\Cms\Block $block */
 ?>
 <figure class="gallery">
-  <ul>
-    <?php foreach ($block->images()->toFiles() as $image): ?>
-    <li>
-      <?php snippet('image', [
-        'alt'      => $image->alt(),
-        'contain'  => $block->crop()->isTrue(),
-        'lightbox' => true,
-        'ratio'    => $block->ratio()->or('auto'),
-        'src'      => $image->url(),
-      ]) ?>
-    </li>
-    <?php endforeach ?>
-  </ul>
-  <?php if ($block->caption()->isNotEmpty()): ?>
-  <figcaption>
-    <?= $block->caption() ?>
-  </figcaption>
-  <?php endif ?>
+	<ul>
+		<?php foreach ($block->images()->toFiles() as $image): ?>
+		<li>
+			<?php snippet("image", [
+   	"alt" => $image->alt(),
+   	"contain" => $block->crop()->isTrue(),
+   	"lightbox" => true,
+   	"ratio" => $block->ratio()->or("auto"),
+   	"src" => $image->url(),
+   ]); ?>
+		</li>
+		<?php endforeach; ?>
+	</ul>
+	<?php if ($block->caption()->isNotEmpty()): ?>
+	<figcaption>
+		<?= $block->caption() ?>
+	</figcaption>
+	<?php endif; ?>
 </figure>

--- a/site/snippets/blocks/image.php
+++ b/site/snippets/blocks/image.php
@@ -1,44 +1,43 @@
 <?php
 
 /*
-  Snippets are a great way to store code snippets for reuse
-  or to keep your templates clean.
+	Snippets are a great way to store code snippets for reuse
+	or to keep your templates clean.
 
-  Block snippets control the HTML for individual blocks
-  in the blocks field. This image snippet overwrites
-  Kirby's default image block to add custom classes
-  and data attributes.
+	Block snippets control the HTML for individual blocks
+	in the blocks field. This image snippet overwrites
+	Kirby's default image block to add custom classes
+	and data attributes.
 
-  More about snippets:
-  https://getkirby.com/docs/guide/templates/snippets
+	More about snippets:
+	https://getkirby.com/docs/guide/templates/snippets
 */
 
 $src = null;
 
-if ($block->location()->value() === 'web') {
-    $alt = $block->alt();
-    $src = $block->src();
-} else if ($image = $block->image()->toFile()) {
-    $alt = $block->alt()->or($image->alt());
-    $src = $image->url();
+if ($block->location()->value() === "web") {
+	$alt = $block->alt();
+	$src = $block->src();
+} elseif ($image = $block->image()->toFile()) {
+	$alt = $block->alt()->or($image->alt());
+	$src = $image->url();
 }
-
 ?>
 <?php if ($src): ?>
 <figure>
-  <?php snippet('image', [
-    'alt'      => $alt,
-    'contain'  => $block->crop()->isFalse(),
-    'lightbox' => $block->link()->isEmpty(),
-    'href'     => $block->link()->or($src),
-    'src'      => $src,
-    'ratio'    => $block->ratio()->or('auto')
-  ]) ?>
+	<?php snippet("image", [
+ 	"alt" => $alt,
+ 	"contain" => $block->crop()->isFalse(),
+ 	"lightbox" => $block->link()->isEmpty(),
+ 	"href" => $block->link()->or($src),
+ 	"src" => $src,
+ 	"ratio" => $block->ratio()->or("auto"),
+ ]); ?>
 
-  <?php if ($block->caption()->isNotEmpty()): ?>
-  <figcaption class="img-caption">
-    <?= $block->caption() ?>
-  </figcaption>
-  <?php endif ?>
+	<?php if ($block->caption()->isNotEmpty()): ?>
+	<figcaption class="img-caption">
+		<?= $block->caption() ?>
+	</figcaption>
+	<?php endif; ?>
 </figure>
-<?php endif ?>
+<?php endif; ?>

--- a/site/snippets/blocks/video.php
+++ b/site/snippets/blocks/video.php
@@ -1,24 +1,24 @@
 <?php
 /*
-  Snippets are a great way to store code snippets for reuse
-  or to keep your templates clean.
+	Snippets are a great way to store code snippets for reuse
+	or to keep your templates clean.
 
-  Block snippets control the HTML for individual blocks
-  in the blocks field. This video snippet overwrites
-  Kirby's default video block to add custom classes
-  and style attributes.
+	Block snippets control the HTML for individual blocks
+	in the blocks field. This video snippet overwrites
+	Kirby's default video block to add custom classes
+	and style attributes.
 
-  More about snippets:
-  https://getkirby.com/docs/guide/templates/snippets
+	More about snippets:
+	https://getkirby.com/docs/guide/templates/snippets
 */
 ?>
 <?php if ($block->url()->isNotEmpty()): ?>
 <figure>
-  <span class="video" style="--w:16;--h:9">
-    <?= video($block->url()) ?>
-  </span>
-  <?php if ($block->caption()->isNotEmpty()): ?>
-  <figcaption class="video-caption"><?= $block->caption() ?></figcaption>
-  <?php endif ?>
+	<span class="video" style="--w:16;--h:9">
+		<?= video($block->url()) ?>
+	</span>
+	<?php if ($block->caption()->isNotEmpty()): ?>
+	<figcaption class="video-caption"><?= $block->caption() ?></figcaption>
+	<?php endif; ?>
 </figure>
-<?php endif ?>
+<?php endif; ?>

--- a/site/snippets/footer.php
+++ b/site/snippets/footer.php
@@ -1,61 +1,61 @@
 <?php
 /*
-  Snippets are a great way to store code snippets for reuse
-  or to keep your templates clean.
+	Snippets are a great way to store code snippets for reuse
+	or to keep your templates clean.
 
-  This footer snippet is reused in all templates.
+	This footer snippet is reused in all templates.
 
-  More about snippets:
-  https://getkirby.com/docs/guide/templates/snippets
+	More about snippets:
+	https://getkirby.com/docs/guide/templates/snippets
 */
 ?>
-  </main>
+	</main>
 
-  <footer class="footer">
-    <div class="grid">
-      <div class="column" style="--columns: 2">
-        <h2>Restez informés grâce à la feuille de chou</h2>
-        <p>
-          formulaire d'abonnement à la newsletter
-        </p>
-      </div>
+	<footer class="footer">
+		<div class="grid">
+			<div class="column" style="--columns: 2">
+				<h2>Restez informés grâce à la feuille de chou</h2>
+				<p>
+					formulaire d'abonnement à la newsletter
+				</p>
+			</div>
 
-      <div class="column" style="--columns: 5">
-        <?php snippet('horaires') ?>
-        <br>
-        <h2>Infos aux livreur·euse·s</h2>
-        <img src="assets/icons/picto-livraison.png" alt="picto camion de livraison" style="width: 50px">
-        <p>
-          Horaires de livraison : du lundi au samedi de 9h30 à 12h30
-        </p>
-      </div>
-      <div class="column" style="--columns: 2">
-        <h2>Pages</h2>
-        <ul>
-          <?php foreach ($site->children()->listed() as $example): ?>
-          <li><a href="<?= $example->url() ?>"><?= $example->title()->esc() ?></a></li>
-          <?php endforeach ?>
-        </ul>
-      </div>
-      <div class="column" style="--columns: 3">
-        <h2>Nous trouver</h2>
-        <img src="assets/images/plan-300x112.png" alt="plan d'accès à la Coop" style="width: 300px">
-        <p>
-          Adresse: 3 rue de Lorraine 56860 Séné
-        </p>
-        <p>
-          Tel:  02 90 73 89 72
-        </p>
-      </div>
-    </div>
-  </footer>
+			<div class="column" style="--columns: 5">
+				<?php snippet("horaires"); ?>
+				<br>
+				<h2>Infos aux livreur·euse·s</h2>
+				<img src="assets/icons/picto-livraison.png" alt="picto camion de livraison" style="width: 50px">
+				<p>
+					Horaires de livraison : du lundi au samedi de 9h30 à 12h30
+				</p>
+			</div>
+			<div class="column" style="--columns: 2">
+				<h2>Pages</h2>
+				<ul>
+					<?php foreach ($site->children()->listed() as $example): ?>
+						<li><a href="<?= $example->url() ?>"><?= $example->title()->esc() ?></a></li>
+					<?php endforeach; ?>
+				</ul>
+			</div>
+			<div class="column" style="--columns: 3">
+				<h2>Nous trouver</h2>
+				<img src="assets/images/plan-300x112.png" alt="plan d'accès à la Coop" style="width: 300px">
+				<p>
+					Adresse: 3 rue de Lorraine 56860 Séné
+				</p>
+				<p>
+					Tel:  02 90 73 89 72
+				</p>
+			</div>
+		</div>
+	</footer>
 
-  <?= js([
-    'assets/js/prism.js',
-    'assets/js/lightbox.js',
-    'assets/js/index.js',
-    '@auto'
-  ]) ?>
+	<?= js([
+ 	"assets/js/prism.js",
+ 	"assets/js/lightbox.js",
+ 	"assets/js/index.js",
+ 	"@auto",
+ ]) ?>
 
 </body>
 </html>

--- a/site/snippets/header.php
+++ b/site/snippets/header.php
@@ -1,83 +1,80 @@
 <?php
 /*
-  Snippets are a great way to store code snippets for reuse
-  or to keep your templates clean.
+	Snippets are a great way to store code snippets for reuse
+	or to keep your templates clean.
 
-  This header snippet is reused in all templates.
-  It fetches information from the `site.txt` content file
-  and contains the site navigation.
+	This header snippet is reused in all templates.
+	It fetches information from the `site.txt` content file
+	and contains the site navigation.
 
-  More about snippets:
-  https://getkirby.com/docs/guide/templates/snippets
+	More about snippets:
+	https://getkirby.com/docs/guide/templates/snippets
 */
 ?>
 <!DOCTYPE html>
 <html lang="en">
-<head>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width,initial-scale=1.0">
 
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+		<?php
+		/*
+			In the title tag we show the title of our
+			site and the title of the current page
+		*/
+		?>
+		<title><?= $site->title()->esc() ?> | <?= $page->title()->esc() ?></title>
 
-  <?php
-  /*
-    In the title tag we show the title of our
-    site and the title of the current page
-  */
-  ?>
-  <title><?= $site->title()->esc() ?> | <?= $page->title()->esc() ?></title>
+		<?php
+		/*
+			Stylesheets can be included using the `css()` helper.
+			Kirby also provides the `js()` helper to include script file.
+			More Kirby helpers: https://getkirby.com/docs/reference/templates/helpers
+		*/
+		?>
+		<?= css([
+			'assets/css/prism.css',
+			'assets/css/lightbox.css',
+			'assets/css/index.css',
+			'@auto'
+		]) ?>
 
-  <?php
-  /*
-    Stylesheets can be included using the `css()` helper.
-    Kirby also provides the `js()` helper to include script file.
-    More Kirby helpers: https://getkirby.com/docs/reference/templates/helpers
-  */
-  ?>
-  <?= css([
-    'assets/css/prism.css',
-    'assets/css/lightbox.css',
-    'assets/css/index.css',
-    '@auto'
-  ]) ?>
-
-  <?php
-  /*
-    The `url()` helper is a great way to create reliable
-    absolute URLs in Kirby that always start with the
-    base URL of your site.
-  */
-  ?>
-  <link rel="shortcut icon" type="image/x-icon" href="<?= url('favicon.ico') ?>">
-</head>
+		<?php
+		/*
+			The `url()` helper is a great way to create reliable
+			absolute URLs in Kirby that always start with the
+			base URL of your site.
+		*/
+		?>
+		<link rel="shortcut icon" type="image/x-icon" href="<?= url('favicon.ico') ?>">
+	</head>
 <body>
+	<header class="header">
+		<a class="logo" href="<?= $site->url() ?>">
+			<?php if ($logo = $site->file($site->logo())): ?>
+				<?= $logo ?>
+			<?php endif ?>
+		</a>
 
-  <header class="header">
-    <a class="logo" href="<?= $site->url() ?>">
-      <?php if ($logo = $site->file($site->logo())): ?>
-        <?= $logo ?>
-      <?php endif ?>
-    </a>
+		<nav class="menu">
+			<a <?php e($site->homePage()->isOpen(), 'aria-current="page"') ?> href="<?= $site->homePage()->url() ?>">Accueil</a>
+			<?php
+			/*
+				In the menu, we only fetch listed pages,
+				i.e. the pages that have a prepended number
+				in their foldername.
 
-    <nav class="menu">
-      <a <?php e($site->homePage()->isOpen(), 'aria-current="page"') ?> href="<?= $site->homePage()->url() ?>">Accueil</a>
-      <?php
-      /*
-        In the menu, we only fetch listed pages,
-        i.e. the pages that have a prepended number
-        in their foldername.
+				We do not want to display links to unlisted
+				`error`, `home`, or `sandbox` pages.
 
-        We do not want to display links to unlisted
-        `error`, `home`, or `sandbox` pages.
-
-        More about page status:
-        https://getkirby.com/docs/reference/panel/blueprints/page#statuses
-      */
-      ?>
-      <?php foreach ($site->children()->listed() as $item): ?>
-      <a <?php e($item->isOpen(), 'aria-current="page"') ?> href="<?= $item->url() ?>"><?= $item->title()->esc() ?></a>
-      <?php endforeach ?>
-      <?php snippet('social') ?>
-    </nav>
-  </header>
-
-  <main class="main">
+				More about page status:
+				https://getkirby.com/docs/reference/panel/blueprints/page#statuses
+			*/
+			?>
+			<?php foreach ($site->children()->listed() as $item): ?>
+			<a <?php e($item->isOpen(), 'aria-current="page"') ?> href="<?= $item->url() ?>"><?= $item->title()->esc() ?></a>
+			<?php endforeach ?>
+			<?php snippet('social') ?>
+		</nav>
+	</header>
+	<main class="main">

--- a/site/snippets/horaires.php
+++ b/site/snippets/horaires.php
@@ -1,10 +1,10 @@
 <h2>Horaires d'ouverture</h2>
 <ul>
-  <li>Lundi : 10h à 12h30 | 15h à 19h</li>
-  <li>Mardi : 10h à 12h30</li>
-  <li>Mercredi : 10h à 12h30 | 15h à 19h</li>
-  <li>Jeudi : 10h à 12h30 | 15h à 19h</li>
-  <li>Vendredi : 10h à 12h30 | 15h à 19h</li>
-  <li>Samedi : 10h à 12h30 | 15h à 17h30</li>
-  <li>Dimanche : fermé</li>
+	<li>Lundi : 10h à 12h30 | 15h à 19h</li>
+	<li>Mardi : 10h à 12h30</li>
+	<li>Mercredi : 10h à 12h30 | 15h à 19h</li>
+	<li>Jeudi : 10h à 12h30 | 15h à 19h</li>
+	<li>Vendredi : 10h à 12h30 | 15h à 19h</li>
+	<li>Samedi : 10h à 12h30 | 15h à 17h30</li>
+	<li>Dimanche : fermé</li>
 </ul>

--- a/site/snippets/image.php
+++ b/site/snippets/image.php
@@ -1,18 +1,16 @@
 <?php
 
 $attrs = attr([
-  'data-lightbox' => $lightbox ?? false,
-  'href'          => $href     ?? $src,
-]);
-
-?>
+	"data-lightbox" => $lightbox ?? false,
+	"href" => $href ?? $src,
+]); ?>
 <a <?= $attrs ?>>
-  <img
-    src="<?= esc($src, 'attr') ?>"
-    alt="<?= esc($alt, 'attr') ?>"
-    style="
-      aspect-ratio: <?= $ratio ?? 'auto' ?>;
-      object-fit: <?= ($contain ?? false) ? 'contain' : 'cover' ?>
-    "
-  >
+	<img
+		src="<?= esc($src, "attr") ?>"
+		alt="<?= esc($alt, "attr") ?>"
+		style="
+			aspect-ratio: <?= $ratio ?? "auto" ?>;
+			object-fit: <?= $contain ?? false ? "contain" : "cover" ?>
+		"
+	>
 </a>

--- a/site/snippets/intro.php
+++ b/site/snippets/intro.php
@@ -1,20 +1,20 @@
 <?php
 /*
-  Snippets are a great way to store code snippets for reuse
-  or to keep your templates clean.
+	Snippets are a great way to store code snippets for reuse
+	or to keep your templates clean.
 
-  This intro snippet is reused in multiple templates.
-  While it does not contain much code, it helps to keep your
-  code DRY and thus facilitate maintenance when you have
-  to make changes.
+	This intro snippet is reused in multiple templates.
+	While it does not contain much code, it helps to keep your
+	code DRY and thus facilitate maintenance when you have
+	to make changes.
 
-  More about snippets:
-  https://getkirby.com/docs/guide/templates/snippets
+	More about snippets:
+	https://getkirby.com/docs/guide/templates/snippets
 */
 ?>
 <header class="h1">
-  <h1><?= $page->headline()->or($page->title())->esc() ?></h1>
-  <?php if ($page->subheadline()->isNotEmpty()): ?>
-  <p class="color-grey"><?= $page->subheadline()->esc() ?></p>
-  <?php endif ?>
+	<h1><?= $page->headline()->or($page->title())->esc() ?></h1>
+	<?php if ($page->subheadline()->isNotEmpty()): ?>
+	<p class="color-grey"><?= $page->subheadline()->esc() ?></p>
+	<?php endif; ?>
 </header>

--- a/site/snippets/social.php
+++ b/site/snippets/social.php
@@ -1,21 +1,21 @@
 <?php
 /*
-  Snippets are a great way to store code snippets for reuse
-  or to keep your templates clean.
+	Snippets are a great way to store code snippets for reuse
+	or to keep your templates clean.
 
-  In this snippet the svg() helper is a great way to embed SVG
-  code directly in your HTML. Pass the path to your SVG
-  file to load it.
+	In this snippet the svg() helper is a great way to embed SVG
+	code directly in your HTML. Pass the path to your SVG
+	file to load it.
 
-  More about snippets:
-  https://getkirby.com/docs/guide/templates/snippets
+	More about snippets:
+	https://getkirby.com/docs/guide/templates/snippets
 */
 ?>
 <span class="social">
-  <a href="https://www.facebook.com/coopdesvenetes/" aria-label="Suivez-nous sur Facebook">
-    <?= svg('assets/icons/facebook.svg') ?>
-  </a>
-  <a href="https://www.instagram.com/coop_des_venetes/" aria-label="Suivez-nous sur Instagram">
-    <?= svg('assets/icons/instagram.svg') ?>
-  </a>
+	<a href="https://www.facebook.com/coopdesvenetes/" aria-label="Suivez-nous sur Facebook">
+		<?= svg("assets/icons/facebook.svg") ?>
+	</a>
+	<a href="https://www.instagram.com/coop_des_venetes/" aria-label="Suivez-nous sur Instagram">
+		<?= svg("assets/icons/instagram.svg") ?>
+	</a>
 </span>

--- a/site/templates/association.php
+++ b/site/templates/association.php
@@ -1,30 +1,30 @@
 <?php
 /*
-  Templates render the content of your pages.
+	Templates render the content of your pages.
 
-  They contain the markup together with some control structures
-  like loops or if-statements. The `$page` variable always
-  refers to the currently active page.
+	They contain the markup together with some control structures
+	like loops or if-statements. The `$page` variable always
+	refers to the currently active page.
 
-  To fetch the content from each field we call the field name as a
-  method on the `$page` object, e.g. `$page->title()`.
+	To fetch the content from each field we call the field name as a
+	method on the `$page` object, e.g. `$page->title()`.
 
-  This default template must not be removed. It is used whenever Kirby
-  cannot find a template with the name of the content file.
+	This default template must not be removed. It is used whenever Kirby
+	cannot find a template with the name of the content file.
 
-  Snippets like the header and footer contain markup used in
-  multiple templates. They also help to keep templates clean.
+	Snippets like the header and footer contain markup used in
+	multiple templates. They also help to keep templates clean.
 
-  More about templates: https://getkirby.com/docs/guide/templates/basics
+	More about templates: https://getkirby.com/docs/guide/templates/basics
 */
 ?>
-<?php snippet('header') ?>
+<?php snippet("header"); ?>
 
 <article>
-  <h1 class="h1"><?= $page->title()->esc() ?></h1>
-  <div class="text">
-    <?= $page->text()->kt() ?>
-  </div>
+	<h1 class="h1"><?= $page->title()->esc() ?></h1>
+	<div class="text">
+		<?= $page->text()->kt() ?>
+	</div>
 </article>
 
-<?php snippet('footer') ?>
+<?php snippet("footer"); ?>

--- a/site/templates/contact.php
+++ b/site/templates/contact.php
@@ -1,50 +1,50 @@
 <?php
 /*
-  Templates render the content of your pages.
+	Templates render the content of your pages.
 
-  They contain the markup together with some control structures
-  like loops or if-statements. The `$page` variable always
-  refers to the currently active page.
+	They contain the markup together with some control structures
+	like loops or if-statements. The `$page` variable always
+	refers to the currently active page.
 
-  To fetch the content from each field we call the field name as a
-  method on the `$page` object, e.g. `$page->title()`.
+	To fetch the content from each field we call the field name as a
+	method on the `$page` object, e.g. `$page->title()`.
 
-  This about page example uses the content from our layout field
-  to create most parts of the page and keeps it modular. Only the
-  contact box at the bottom is pre-defined with a set of fields
-  in the about.yml blueprint.
+	This about page example uses the content from our layout field
+	to create most parts of the page and keeps it modular. Only the
+	contact box at the bottom is pre-defined with a set of fields
+	in the about.yml blueprint.
 
-  Snippets like the header and footer contain markup used in
-  multiple templates. They also help to keep templates clean.
+	Snippets like the header and footer contain markup used in
+	multiple templates. They also help to keep templates clean.
 
-  More about templates: https://getkirby.com/docs/guide/templates/basics
+	More about templates: https://getkirby.com/docs/guide/templates/basics
 */
 ?>
-<?php snippet('header') ?>
-<?php snippet('intro') ?>
+<?php snippet("header"); ?>
+<?php snippet("intro"); ?>
 
 <aside class="contact">
-  <h2 class="h1">Get in contact</h2>
-  <div class="grid" style="--gutter: 1.5rem">
-    <section class="column text" style="--columns: 4">
-      <h3>Address</h3>
-      <?= $page->address() ?>
-    </section>
-    <section class="column text" style="--columns: 4">
-      <h3>Email</h3>
-      <p><?= Html::email($page->email()) ?></p>
-      <h3>Phone</h3>
-      <p><?= Html::tel($page->phone()) ?></p>
-    </section>
-    <section class="column text" style="--columns: 4">
-      <h3>On the web</h3>
-      <ul>
-        <?php foreach ($page->social()->toStructure() as $social): ?>
-        <li><?= Html::a($social->url(), $social->platform()) ?></li>
-        <?php endforeach ?>
-      </ul>
-    </section>
-  </div>
+	<h2 class="h1">Get in contact</h2>
+	<div class="grid" style="--gutter: 1.5rem">
+		<section class="column text" style="--columns: 4">
+			<h3>Address</h3>
+			<?= $page->address() ?>
+		</section>
+		<section class="column text" style="--columns: 4">
+			<h3>Email</h3>
+			<p><?= Html::email($page->email()) ?></p>
+			<h3>Phone</h3>
+			<p><?= Html::tel($page->phone()) ?></p>
+		</section>
+		<section class="column text" style="--columns: 4">
+			<h3>On the web</h3>
+			<ul>
+				<?php foreach ($page->social()->toStructure() as $social): ?>
+				<li><?= Html::a($social->url(), $social->platform()) ?></li>
+				<?php endforeach; ?>
+			</ul>
+		</section>
+	</div>
 </aside>
 
-<?php snippet('footer') ?>
+<?php snippet("footer"); ?>

--- a/site/templates/default.php
+++ b/site/templates/default.php
@@ -1,30 +1,30 @@
 <?php
 /*
-  Templates render the content of your pages.
+	Templates render the content of your pages.
 
-  They contain the markup together with some control structures
-  like loops or if-statements. The `$page` variable always
-  refers to the currently active page.
+	They contain the markup together with some control structures
+	like loops or if-statements. The `$page` variable always
+	refers to the currently active page.
 
-  To fetch the content from each field we call the field name as a
-  method on the `$page` object, e.g. `$page->title()`.
+	To fetch the content from each field we call the field name as a
+	method on the `$page` object, e.g. `$page->title()`.
 
-  This default template must not be removed. It is used whenever Kirby
-  cannot find a template with the name of the content file.
+	This default template must not be removed. It is used whenever Kirby
+	cannot find a template with the name of the content file.
 
-  Snippets like the header and footer contain markup used in
-  multiple templates. They also help to keep templates clean.
+	Snippets like the header and footer contain markup used in
+	multiple templates. They also help to keep templates clean.
 
-  More about templates: https://getkirby.com/docs/guide/templates/basics
+	More about templates: https://getkirby.com/docs/guide/templates/basics
 */
 ?>
-<?php snippet('header') ?>
+<?php snippet("header"); ?>
 
 <article>
-  <h1 class="h1"><?= $page->title()->esc() ?></h1>
-  <div class="text">
-    <?= $page->text()->kt() ?>
-  </div>
+	<h1 class="h1"><?= $page->title()->esc() ?></h1>
+	<div class="text">
+		<?= $page->text()->kt() ?>
+	</div>
 </article>
 
-<?php snippet('footer') ?>
+<?php snippet("footer"); ?>

--- a/site/templates/devenir_cooperateur.php
+++ b/site/templates/devenir_cooperateur.php
@@ -1,30 +1,30 @@
 <?php
 /*
-  Templates render the content of your pages.
+	Templates render the content of your pages.
 
-  They contain the markup together with some control structures
-  like loops or if-statements. The `$page` variable always
-  refers to the currently active page.
+	They contain the markup together with some control structures
+	like loops or if-statements. The `$page` variable always
+	refers to the currently active page.
 
-  To fetch the content from each field we call the field name as a
-  method on the `$page` object, e.g. `$page->title()`.
+	To fetch the content from each field we call the field name as a
+	method on the `$page` object, e.g. `$page->title()`.
 
-  This default template must not be removed. It is used whenever Kirby
-  cannot find a template with the name of the content file.
+	This default template must not be removed. It is used whenever Kirby
+	cannot find a template with the name of the content file.
 
-  Snippets like the header and footer contain markup used in
-  multiple templates. They also help to keep templates clean.
+	Snippets like the header and footer contain markup used in
+	multiple templates. They also help to keep templates clean.
 
-  More about templates: https://getkirby.com/docs/guide/templates/basics
+	More about templates: https://getkirby.com/docs/guide/templates/basics
 */
 ?>
-<?php snippet('header') ?>
+<?php snippet("header"); ?>
 
 <article>
-  <h1 class="h1"><?= $page->title()->esc() ?></h1>
-  <div class="text">
-    <?= $page->text()->kt() ?>
-  </div>
+	<h1 class="h1"><?= $page->title()->esc() ?></h1>
+	<div class="text">
+		<?= $page->text()->kt() ?>
+	</div>
 </article>
 
-<?php snippet('footer') ?>
+<?php snippet("footer"); ?>

--- a/site/templates/home.php
+++ b/site/templates/home.php
@@ -1,44 +1,43 @@
 <?php
 /*
-  Templates render the content of your pages.
+	Templates render the content of your pages.
 
-  They contain the markup together with some control structures
-  like loops or if-statements. The `$page` variable always
-  refers to the currently active page.
+	They contain the markup together with some control structures
+	like loops or if-statements. The `$page` variable always
+	refers to the currently active page.
 
-  To fetch the content from each field we call the field name as a
-  method on the `$page` object, e.g. `$page->title()`.
+	To fetch the content from each field we call the field name as a
+	method on the `$page` object, e.g. `$page->title()`.
 
-  This home template renders content from others pages, the children of
-  the `photography` page to display a nice gallery grid.
+	This home template renders content from others pages, the children of
+	the `photography` page to display a nice gallery grid.
 
-  Snippets like the header and footer contain markup used in
-  multiple templates. They also help to keep templates clean.
+	Snippets like the header and footer contain markup used in
+	multiple templates. They also help to keep templates clean.
 
-  More about templates: https://getkirby.com/docs/guide/templates/basics
+	More about templates: https://getkirby.com/docs/guide/templates/basics
 */
-
 ?>
-<?= snippet('header') ?>
-<?= snippet('intro') ?>
+<?= snippet("header") ?>
+<?= snippet("intro") ?>
 <?php
-  /*
-    We always use an if-statement to check if a page exists to
-    prevent errors in case the page was deleted or renamed before
-    we call a method like `children()` in this case
-  */
+/*
+		We always use an if-statement to check if a page exists to
+		prevent errors in case the page was deleted or renamed before
+		we call a method like `children()` in this case
+	*/
 ?>
 
 <?php foreach ($page->layout()->toLayouts() as $layout): ?>
 <section class="grid" id="<?= $layout->id() ?>">
-  <?php foreach ($layout->columns() as $column): ?>
-  <div class="column" style="--span:<?= $column->span() ?>">
-    <div class="blocks">
-      <?= $column->blocks() ?>
-    </div>
-  </div>
-  <?php endforeach ?>
+	<?php foreach ($layout->columns() as $column): ?>
+	<div class="column" style="--span:<?= $column->span() ?>">
+		<div class="blocks">
+			<?= $column->blocks() ?>
+		</div>
+	</div>
+	<?php endforeach; ?>
 </section>
-<?php endforeach ?>
+<?php endforeach; ?>
 
-<?= snippet('footer') ?>
+<?= snippet("footer") ?>

--- a/site/templates/magasin.php
+++ b/site/templates/magasin.php
@@ -1,30 +1,30 @@
 <?php
 /*
-  Templates render the content of your pages.
+	Templates render the content of your pages.
 
-  They contain the markup together with some control structures
-  like loops or if-statements. The `$page` variable always
-  refers to the currently active page.
+	They contain the markup together with some control structures
+	like loops or if-statements. The `$page` variable always
+	refers to the currently active page.
 
-  To fetch the content from each field we call the field name as a
-  method on the `$page` object, e.g. `$page->title()`.
+	To fetch the content from each field we call the field name as a
+	method on the `$page` object, e.g. `$page->title()`.
 
-  This default template must not be removed. It is used whenever Kirby
-  cannot find a template with the name of the content file.
+	This default template must not be removed. It is used whenever Kirby
+	cannot find a template with the name of the content file.
 
-  Snippets like the header and footer contain markup used in
-  multiple templates. They also help to keep templates clean.
+	Snippets like the header and footer contain markup used in
+	multiple templates. They also help to keep templates clean.
 
-  More about templates: https://getkirby.com/docs/guide/templates/basics
+	More about templates: https://getkirby.com/docs/guide/templates/basics
 */
 ?>
-<?php snippet('header') ?>
+<?php snippet("header"); ?>
 
 <article>
-  <h1 class="h1"><?= $page->title()->esc() ?></h1>
-  <div class="text">
-    <?= $page->text()->kt() ?>
-  </div>
+	<h1 class="h1"><?= $page->title()->esc() ?></h1>
+	<div class="text">
+		<?= $page->text()->kt() ?>
+	</div>
 </article>
 
-<?php snippet('footer') ?>
+<?php snippet("footer"); ?>


### PR DESCRIPTION
Using tab instead of space for indent is a preference that make sense for me. I find it more accessible, more logical.

Unfortunately some languages, like YAML, require the indent to be in space.

So I propose to use tab when possible and use what is required for specific languages. To help with that, I add [prettier](https://prettier.io/) to help for the formatting with the help of a [code editor extension](https://prettier.io/docs/en/editors) or the command line.